### PR TITLE
Adds readme to js-action's glob

### DIFF
--- a/src/glob-patterns.ts
+++ b/src/glob-patterns.ts
@@ -4,7 +4,7 @@ import type { Arguments } from './types';
 
 const templates: Record<string, string[]> = {
   'composite-action': ['action.{yml,yaml}', 'LICENSE'],
-  'javascript-action': ['action.{yml,yaml}', 'dist/**', 'LICENSE'],
+  'javascript-action': ['action.{yml,yaml}', 'dist/**', 'LICENSE', 'README{,.md}'],
 };
 
 const extractNames = (input: string) =>


### PR DESCRIPTION
The readme should be included in the tag as well. Otherwise when selecting an older version in the marketplace there is no readme displayed.

See also here: https://github.com/JasonEtco/build-and-tag-action/pull/18#issuecomment-1386746993